### PR TITLE
fix for JNI table overflow

### DIFF
--- a/jni/libvorbis-jni/org_xiph_vorbis_encoder_VorbisEncoder.c
+++ b/jni/libvorbis-jni/org_xiph_vorbis_encoder_VorbisEncoder.c
@@ -61,6 +61,9 @@ int writeVorbisDataToEncoderDataFeed(JNIEnv *env, jobject* encoderDataFeed, jmet
     //Call the write vorbis data method
     int amountWritten = (*env)->CallIntMethod(env, (*encoderDataFeed), (*writeVorbisDataMethodId), (*jByteArrayWriteBuffer), bytes);
 
+    // clean up
+    (*env)->DeleteLocalRef(env, jByteArray);
+
     //Return the amount that was actually written
     return amountWritten;
 }


### PR DESCRIPTION
This fixes the JNI reference table overflow discussed at https://github.com/vincentjames501/libvorbis-libogg-android/issues/9